### PR TITLE
:bug: Fix initialization of fitted attribute

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,6 +8,11 @@ on:
 
 jobs:
     check:
+        permissions:
+            # Give the default GITHUB_TOKEN write permission to commit and push the
+            # added or changed files to the repository.
+            contents: write
+
         strategy:
             fail-fast: false
             matrix:
@@ -18,3 +23,4 @@ jobs:
             os: ${{ matrix.os }}
             python: ${{ matrix.python }}
             command: task check
+            push: true

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -12,6 +12,9 @@ on:
             command:
                 required: true
                 type: string
+            push:
+                required: false
+                type: boolean
 
 env:
     POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}
@@ -55,3 +58,10 @@ jobs:
             -   name: Command
                 run: ${{ inputs.command }}
                 shell: bash
+
+            -   name: Push
+                if: ${{ inputs.push && inputs.os == 'ubuntu-latest' }}
+                # Commit all changed files back to the repository
+                uses: stefanzweifel/git-auto-commit-action@v5
+                with:
+                    commit_message: ":white_check_mark: automated change [skip ci]"

--- a/assets/coverage.svg
+++ b/assets/coverage.svg
@@ -9,13 +9,13 @@
     </mask>
     <g mask="url(#a)">
         <path fill="#555" d="M0 0h63v20H0z"/>
-        <path fill="#dfb317" d="M63 0h36v20H63z"/>
+        <path fill="#4c1" d="M63 0h36v20H63z"/>
         <path fill="url(#b)" d="M0 0h99v20H0z"/>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">65%</text>
-        <text x="80" y="14">65%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">95%</text>
+        <text x="80" y="14">95%</text>
     </g>
 </svg>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "nearness"
-version = "0.1.0"
+version = "0.1.1"
 description = "An easy-to-use interface for (approximate) nearest neighbors algorithms."
 readme = "README.md"
 authors = ["David Muhr <muhrdavid+github@gmail.com>"]

--- a/src/nearness/_annoy.py
+++ b/src/nearness/_annoy.py
@@ -42,7 +42,7 @@ class AnnoyNeighbors(NearestNeighbors):
             index = AnnoyIndex(self.parameters.load_index_dim, self.parameters.metric)
             index.load(str(path))
             self._index = index
-            self.is_fitted = True
+            self.__fitted__ = True
 
     @overload
     def fit(self, data: Iterable[Real[NumpyArray, "d"]]) -> "AnnoyNeighbors": ...

--- a/tests/test_nearness.py
+++ b/tests/test_nearness.py
@@ -362,7 +362,6 @@ def test_thread_safety():
 
         # Get the current thread id
         thread_id = threading.current_thread().ident
-        original_thread_ids.add(thread_id)
 
         # Set the thread id on the model
         model = Model(thread_id=thread_id)
@@ -398,14 +397,16 @@ def test_keyword_only():
     with pytest.raises(InvalidSignatureError):
 
         class N(NearestNeighbors):
-            def __init__(self, a): ...
+            def __init__(self, a):
+                super().__init__()
 
 
 def test_warn_check():
     class ModelNoConfig(NearestNeighbors):
         no_method = True
 
-        def __init__(self): ...
+        def __init__(self):
+            super().__init__()
 
         def fit(self, data): ...
 
@@ -415,6 +416,7 @@ def test_warn_check():
         no_method = True
 
         def __init__(self):
+            super().__init__()
             self.config.methods_require_fit = self.config.methods_require_fit | {"no_method"}
 
         def fit(self, data): ...
@@ -423,6 +425,7 @@ def test_warn_check():
 
     class ModelMissingAttribute(NearestNeighbors):
         def __init__(self):
+            super().__init__()
             self.config.methods_require_fit = self.config.methods_require_fit | {"missing_method"}
 
         def fit(self, data): ...
@@ -446,7 +449,8 @@ def test_warn_check():
 
 def test_check_attribute():
     class Model(NearestNeighbors):
-        def __init__(self): ...
+        def __init__(self):
+            super().__init__()
 
         def fit(self, data):
             return self


### PR DESCRIPTION
## Description

Some algorithms might load an existing index during initialization, but it was assumed that ``__fitted__ = False`` after initialization. This PR ensures that the ``__fitted__`` attribute is correct after initialization and warns if ``__fitted__`` is not set, meaning that ``super().__init__()`` was not called.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ x ] 🔧 Bug fix
- [ ] 🔐 Security fix
- [ ] 🚀 Improvement / New feature
- [ ] 📚 Examples / Docs / Tutorials

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ x ] I've checked the code using `task check`.
- [ x ] I've checked the repository using `pre-commit`.
