### PR TITLE
🎨 Improve error messages for positional arguments

### DIFF
--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -67,8 +67,12 @@ jobs:
                     git config --global user.name "github-actions[bot]"
                     git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
+                    # Fetch and check out the pull request branch
                     git fetch origin ${{ github.head_ref }}
                     git checkout ${{ github.head_ref }}
+
+                    # Ensure we're up to date with the remote (without merge commits)
+                    git pull --ff-only origin ${{ github.head_ref }}
 
                     # Stage and commit changes
                     git add .

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -64,10 +64,17 @@ jobs:
             -   name: Push
                 if: ${{ inputs.push && inputs.os == 'ubuntu-latest' && github.event_name == 'pull_request' }}
                 run: |
-                  git config --global user.name "github-actions[bot]"
-                  git config --global user.email "github-actions[bot]@users.noreply.github.com"
-                  git fetch origin
-                  git rebase origin/${{ github.head_ref }} || git rebase --abort
-                  git add .
-                  git commit -m ":white_check_mark: automated change [skip ci]" || echo "No changes to commit"
-                  git push origin HEAD:${{ github.head_ref }}
+                    git config --global user.name "github-actions[bot]"
+                    git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+                    git fetch origin ${{ github.head_ref }}
+                    git checkout ${{ github.head_ref }}
+
+                    # Stage and commit changes
+                    git add .
+                    if git diff --cached --quiet; then
+                        echo "No changes to commit"
+                    else
+                        git commit -m ":white_check_mark: automated change [skip ci]" || echo "No changes to commit"
+                        git push origin HEAD:${{ github.head_ref }}
+                    fi

--- a/assets/coverage.svg
+++ b/assets/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">54%</text>
-        <text x="80" y="14">54%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">55%</text>
+        <text x="80" y="14">55%</text>
     </g>
 </svg>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "nearness"
-version = "0.2.3"
+version = "0.2.4"
 description = "An easy-to-use interface for (approximate) nearest neighbors algorithms."
 readme = "README.md"
 authors = ["David Muhr <muhrdavid+github@gmail.com>"]


### PR DESCRIPTION
## Description

It was possible to provide positional arguments despite not being used.
An error is now thrown when positional arguments are supplied.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 🔧 Bug fix
- [ ] 🔐 Security fix
- [ x ] 🚀 Improvement / New feature
- [ ] 📚 Examples / Docs / Tutorials

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ x ] I've checked the code using `task check`.
- [ x ] I've checked the repository using `pre-commit`.
